### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dwave-ocean-sdk>=3.3.0
-
+matplotlib>=3.3.0


### PR DESCRIPTION
Add `matplotlib` back mistakenly removed in #20.